### PR TITLE
Missing enum values and optional field

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,7 +207,7 @@ pub struct Maneuver {
 
     /// Text suitable for use as a verbal message immediately prior to the maneuver transition. For
     /// example "Turn right onto North Prince Street, U.S. 2 22".
-    pub verbal_pre_transition_instruction: String,
+    pub verbal_pre_transition_instruction: Option<String>,
     /// Text suitable for use as a verbal message immediately after the maneuver transition. For
     /// example "Continue on U.S. 2 22 for 3.9 miles".
     pub verbal_post_transition_instruction: Option<String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,6 +183,11 @@ pub enum ManeuverType {
     PostTransitConnectionDestination,
     MergeRight,
     MergeLeft,
+    ElevatorEnter,
+    StepsEnter,
+    EscalatorEnter,
+    BuildingEnter,
+    BuildingExit,
 }
 
 #[derive(Deserialize, Clone, Debug)]


### PR DESCRIPTION
Jelmer, thanks for sharing your library!

When using it to query hundreds of thousands of routes in the area of Rotterdam, NL, I regularly received serde serialization errors. As it turned out, the [Valhalla API documentation](https://valhalla.github.io/valhalla/api/turn-by-turn/api-reference/#trip-legs-and-maneuvers) does not display them either, but they are in the code (see my [Valhalla issue](https://github.com/valhalla/valhalla/issues/4666) for more details). 

After fixing that, there was another minor issue: the `verbal_pre_transition_instruction` is optional. 