### PR TITLE
Costing should implement Copy, Clone

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -386,7 +386,7 @@ pub enum BicycleType {
     Mountain,
 }
 
-#[derive(Serialize, Default)]
+#[derive(Serialize, Default, Clone, Copy)]
 pub enum Costing {
     /// Standard costing for driving routes by car, motorcycle, truck, and so on that obeys automobile
     /// driving rules, such as access and turn restrictions. Auto provides a short time path (though


### PR DESCRIPTION
When retrying the route using crate retry, I need to be able to copy or clone the costing too. Example:

```rust
/// Calculate a trip between from and to using costing.
/// When Valhalla cannot find a route, use a straight line and the average speed.
pub fn calc_trip(
    valhalla: &Valhalla,
    from: &LonLat,
    to: &LonLat,
    costing: Costing,
    speed: f64,
) -> RoadTrip {
    let result = retry(Exponential::from_millis(10).map(jitter).take(5), || {
        let manifest = Manifest {
            locations: vec![
                valhalla_client::Location::new(from.0, from.1),
                valhalla_client::Location::new(to.0, to.1),
            ],
            costing,
            ..Default::default()
        };

        let road_trip = match valhalla.route(manifest) {
            Ok(trip) => {
                let (coord, dur) = convert_trip(trip);
                let tot_dur = dur.iter().fold(0, |acc, d| acc + d);
                // println!(
                //     "Route found between ({}, {}) and ({}, {})",
                //     from.1, from.0, to.1, to.0
                // );
                (coord, dur, tot_dur)
            }
            Err(err) => {
                let coord = vec![LonLat(from.0, from.1), LonLat(to.0, to.1)];
                let d = lonlat_distance(&coord[0], &coord[1]);
                let tot_dur = (d / speed).round() as u32;
                eprintln!(
                    "Routing error - using straight line between ({}, {}) and ({}, {}): {}",
                    from.1, from.0, to.1, to.0, err
                );
                (coord, vec![tot_dur], tot_dur)
            }
        };
        Ok::<(Vec<LonLat>, Vec<u32>, u32), Error>(road_trip)
    });
    result.unwrap()
}
```