### PR TITLE
add `#![forbid(unsafe_code)]`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 //! This crate contains the types and functions for interacting with the Valhalla API.
 //!
 //! At the moment, only the routing API is implemented.


### PR DESCRIPTION
Currently, one could use unsafe code in this project. This is not quite nessesary for an API-Wrapper => lets add an assertion that there is no unsafe code.

Motivation: https://github.com/geiger-rs/cargo-geiger