### PR TITLE
add `cargo-semver-checks` support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,6 +23,13 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run tests
         run: cargo test --verbose
+  semver:
+    runs-on: ubuntu-latest
+    name: semver
+    steps:
+      - uses: actions/checkout@v4
+      - name: cargo-semver-checks
+        uses: obi1kenobi/cargo-semver-checks-action@v2
   fmt:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "valhalla-client"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "geo-types",
  "gpx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "valhalla-client"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 description = "API client for the Valhalla routing engine"
 authors = ["Jelmer Vernooĳ <jelmer@jelmer.uk>"]


### PR DESCRIPTION
Similar to clippy, this adds a new set of lints.
More specific, it warns of semver breakage.
Sadly [Predrag](https://github.com/obi1kenobi)s talk from eurorust does not jet have a stream, but hey..

Maybe someday https://rust-lang.github.io/rust-project-goals/2024h2/cargo-semver-checks.html will be done, but until then, this is benefitial..

Being upfront: I have contributed 1.5 lints there..

This also bumps the version to `0.2.0` to make the linter shut up about https://github.com/jelmer/valhalla-client-rs/pull/49 being a Semver breaking change