### PR TITLE
feat!: remove deprecated + unimplemnted HOV costing

### DIFF
--- a/src/route/costing/hov.rs
+++ b/src/route/costing/hov.rs
@@ -1,8 +1,0 @@
-use serde::{Deserialize, Serialize};
-
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
-pub struct HovCostingOptions {
-    /// TODO: implement builder with all option. If you want to contribute this, a PR is appreciated
-    #[serde(skip)]
-    _placeholder: (),
-}

--- a/src/route/costing/mod.rs
+++ b/src/route/costing/mod.rs
@@ -1,7 +1,6 @@
 pub mod auto;
 pub mod bicycle;
 pub mod bikeshare;
-pub mod hov;
 pub mod motor;
 pub mod motorcycle;
 pub mod multimodal;

--- a/src/route/costing/mod.rs
+++ b/src/route/costing/mod.rs
@@ -49,11 +49,6 @@ pub enum Costing {
     /// - weight limits
     #[serde(rename = "truck")]
     Truck(truck::TruckCostingOptions),
-    /// DEPRECATED: use [`Costing::Auto`] with HOV costing options.
-    #[serde(rename = "hov")]
-    // #[deprecated] <- this would cause a compilation warning due to https://github.com/rust-lang/rust/issues/92313
-    #[doc(hidden)]
-    Hov(hov::HovCostingOptions),
     /// Standard costing for taxi routes.
     ///
     /// Taxi costing inherits the [`Costing::Auto`] behaviors, but checks and favors


### PR DESCRIPTION
The HOV costing is currently unused.
Before we cut a new release, we should likely remove it instead of implementing it.

What do you think?