### PR TITLE
refactor: only send the needed fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,18 +118,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "console"
-version = "0.15.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
-dependencies = [
- "encode_unicode",
- "lazy_static",
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -200,12 +188,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "encode_unicode"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
@@ -705,19 +687,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "insta"
-version = "1.41.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e9ffc4d4892617c50a928c52b2961cb5174b6fc6ebf252b2fac9d21955c48b8"
-dependencies = [
- "console",
- "lazy_static",
- "linked-hash-map",
- "serde",
- "similar",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -739,12 +708,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -755,12 +718,6 @@ name = "libm"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
-
-[[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1215,12 +1172,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "similar"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
-
-[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1537,7 +1488,6 @@ version = "0.2.0"
 dependencies = [
  "geo-types",
  "gpx",
- "insta",
  "log",
  "reqwest",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -90,6 +105,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-targets",
+]
+
+[[package]]
 name = "console"
 version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,12 +146,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -306,12 +370,18 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.3.0",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -324,6 +394,12 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -436,6 +512,29 @@ dependencies = [
  "tower",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -557,6 +656,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -579,12 +684,24 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3fc2e30ba82dd1b3911c8de1ffc143c74a914a14e99514d7637e3099df5ea0"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.14.5",
+ "serde",
 ]
 
 [[package]]
@@ -1068,6 +1185,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28bdad6db2b8340e449f7108f020b3b092e8583a9e3fb82713e1d4e71fe817"
+dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.3.0",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d846214a9854ef724f3da161b426242d8de7c1fc7de2f89bb1efcb154dca79d"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "similar"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1109,6 +1256,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -1390,6 +1543,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_repr",
+ "serde_with",
  "url",
 ]
 
@@ -1488,6 +1642,15 @@ checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,6 +90,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "console"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,6 +136,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
@@ -570,6 +588,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.41.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e9ffc4d4892617c50a928c52b2961cb5174b6fc6ebf252b2fac9d21955c48b8"
+dependencies = [
+ "console",
+ "lazy_static",
+ "linked-hash-map",
+ "serde",
+ "similar",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -591,6 +622,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -601,6 +638,12 @@ name = "libm"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1025,6 +1068,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1335,6 +1384,7 @@ version = "0.2.0"
 dependencies = [
  "geo-types",
  "gpx",
+ "insta",
  "log",
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ reqwest = { version = "0.12.9", features = ["blocking", "json"] }
 serde = { version = "1.0.214", features = ["derive"] }
 serde_json = "1.0.132"
 serde_repr = "0.1.19"
+serde_with = "3.11.0"
 url = "2.5.3"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,6 @@ url = "2.5.3"
 [features]
 default = ["gpx"]
 gpx = ["dep:gpx"]
+
+[dev-dependencies]
+insta = { version = "1.41.1", features = ["json"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,3 @@ url = "2.5.3"
 [features]
 default = ["gpx"]
 gpx = ["dep:gpx"]
-
-[dev-dependencies]
-insta = { version = "1.41.1", features = ["json"] }

--- a/src/route/costing/auto.rs
+++ b/src/route/costing/auto.rs
@@ -2,42 +2,78 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct AutoCostingOptions {
+    #[serde(skip_serializing_if = "Option::is_none")]
     maneuver_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     gate_cost: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     gate_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     private_access_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     destination_only_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     toll_booth_cost: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     toll_booth_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     ferry_cost: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     use_ferry: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     use_highways: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     use_tolls: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     use_living_streets: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     use_tracks: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     service_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     service_factor: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     country_crossing_cost: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     country_crossing_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     shortest: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     use_distance: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     disable_hierarchy_pruning: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     top_speed: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     fixed_speed: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     closure_factor: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     ignore_closures: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     ignore_restrictions: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     ignore_oneways: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     ignore_non_vehicular_restrictions: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     ignore_access: Option<bool>,
     // -- ↓ auto/taxi/bus only ↓ --
+    #[serde(skip_serializing_if = "Option::is_none")]
     speed_types: Option<UsedSpeedSources>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     height: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     width: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     exclude_unpaved: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     exclude_cash_only_tolls: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     include_hov2: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     include_hov3: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     include_hot: Option<bool>,
 }
 impl AutoCostingOptions {
@@ -434,4 +470,12 @@ pub enum UsedSpeedSources {
     Predicted,
     #[serde(rename = "current")]
     Current,
+}
+#[cfg(test)]
+mod test{
+    use super::*;
+    #[test]
+    fn serialisation(){
+        insta::assert_json_snapshot!(AutoCostingOptions::default(),@"{}")
+    }
 }

--- a/src/route/costing/auto.rs
+++ b/src/route/costing/auto.rs
@@ -441,6 +441,6 @@ mod test {
     use super::*;
     #[test]
     fn serialisation() {
-        insta::assert_json_snapshot!(AutoCostingOptions::default(),@"{}")
+        assert_eq!(serde_json::to_value(AutoCostingOptions::default()).unwrap(), serde_json::json!({}));
     }
 }

--- a/src/route/costing/auto.rs
+++ b/src/route/costing/auto.rs
@@ -472,10 +472,10 @@ pub enum UsedSpeedSources {
     Current,
 }
 #[cfg(test)]
-mod test{
+mod test {
     use super::*;
     #[test]
-    fn serialisation(){
+    fn serialisation() {
         insta::assert_json_snapshot!(AutoCostingOptions::default(),@"{}")
     }
 }

--- a/src/route/costing/auto.rs
+++ b/src/route/costing/auto.rs
@@ -1,79 +1,44 @@
 use serde::{Deserialize, Serialize};
 
+#[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct AutoCostingOptions {
-    #[serde(skip_serializing_if = "Option::is_none")]
     maneuver_penalty: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     gate_cost: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     gate_penalty: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     private_access_penalty: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     destination_only_penalty: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     toll_booth_cost: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     toll_booth_penalty: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     ferry_cost: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     use_ferry: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     use_highways: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     use_tolls: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     use_living_streets: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     use_tracks: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     service_penalty: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     service_factor: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     country_crossing_cost: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     country_crossing_penalty: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     shortest: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     use_distance: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     disable_hierarchy_pruning: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     top_speed: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     fixed_speed: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     closure_factor: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     ignore_closures: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     ignore_restrictions: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     ignore_oneways: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     ignore_non_vehicular_restrictions: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     ignore_access: Option<bool>,
     // -- ↓ auto/taxi/bus only ↓ --
-    #[serde(skip_serializing_if = "Option::is_none")]
     speed_types: Option<UsedSpeedSources>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     height: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     width: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     exclude_unpaved: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     exclude_cash_only_tolls: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     include_hov2: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     include_hov3: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     include_hot: Option<bool>,
 }
 impl AutoCostingOptions {

--- a/src/route/costing/auto.rs
+++ b/src/route/costing/auto.rs
@@ -441,6 +441,9 @@ mod test {
     use super::*;
     #[test]
     fn serialisation() {
-        assert_eq!(serde_json::to_value(AutoCostingOptions::default()).unwrap(), serde_json::json!({}));
+        assert_eq!(
+            serde_json::to_value(AutoCostingOptions::default()).unwrap(),
+            serde_json::json!({})
+        );
     }
 }

--- a/src/route/costing/bicycle.rs
+++ b/src/route/costing/bicycle.rs
@@ -24,39 +24,25 @@ pub enum BicycleType {
     #[serde(rename = "mountain")]
     Mountain,
 }
+
+#[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct BicycleCostingOptions {
-    #[serde(skip_serializing_if = "Option::is_none")]
     bicycle_type: Option<BicycleType>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     cycling_speed: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     use_roads: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     use_hills: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     use_ferry: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     use_living_streets: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     avoid_bad_surfaces: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     bss_return_cost: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     bss_return_penalty: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     shortest: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     maneuver_penalty: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     gate_cost: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     gate_penalty: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     country_crossing_cost: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     country_crossing_penalty: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     service_penalty: Option<f32>,
 }
 impl BicycleCostingOptions {

--- a/src/route/costing/bicycle.rs
+++ b/src/route/costing/bicycle.rs
@@ -262,10 +262,10 @@ impl BicycleCostingOptions {
 }
 
 #[cfg(test)]
-mod test{
+mod test {
     use super::*;
     #[test]
-    fn serialisation(){
+    fn serialisation() {
         insta::assert_json_snapshot!(BicycleCostingOptions::default(),@"{}")
     }
 }

--- a/src/route/costing/bicycle.rs
+++ b/src/route/costing/bicycle.rs
@@ -26,21 +26,37 @@ pub enum BicycleType {
 }
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct BicycleCostingOptions {
-    bicycle_type: BicycleType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    bicycle_type: Option<BicycleType>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     cycling_speed: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     use_roads: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     use_hills: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     use_ferry: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     use_living_streets: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     avoid_bad_surfaces: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     bss_return_cost: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     bss_return_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     shortest: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     maneuver_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     gate_cost: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     gate_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     country_crossing_cost: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     country_crossing_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     service_penalty: Option<f32>,
 }
 impl BicycleCostingOptions {
@@ -54,7 +70,7 @@ impl BicycleCostingOptions {
     ///
     /// Default: [`BicycleType::Hybrid`]
     pub fn bicycle_type(mut self, bicycle_type: BicycleType) -> Self {
-        self.bicycle_type = bicycle_type;
+        self.bicycle_type = Some(bicycle_type);
         self
     }
 
@@ -242,5 +258,14 @@ impl BicycleCostingOptions {
     pub fn service_penalty(mut self, penalty: f32) -> Self {
         self.service_penalty = Some(penalty);
         self
+    }
+}
+
+#[cfg(test)]
+mod test{
+    use super::*;
+    #[test]
+    fn serialisation(){
+        insta::assert_json_snapshot!(BicycleCostingOptions::default(),@"{}")
     }
 }

--- a/src/route/costing/bicycle.rs
+++ b/src/route/costing/bicycle.rs
@@ -252,6 +252,9 @@ mod test {
     use super::*;
     #[test]
     fn serialisation() {
-        assert_eq!(serde_json::to_value(BicycleCostingOptions::default()).unwrap(), serde_json::json!({}));
+        assert_eq!(
+            serde_json::to_value(BicycleCostingOptions::default()).unwrap(),
+            serde_json::json!({})
+        );
     }
 }

--- a/src/route/costing/bicycle.rs
+++ b/src/route/costing/bicycle.rs
@@ -252,6 +252,6 @@ mod test {
     use super::*;
     #[test]
     fn serialisation() {
-        insta::assert_json_snapshot!(BicycleCostingOptions::default(),@"{}")
+        assert_eq!(serde_json::to_value(BicycleCostingOptions::default()).unwrap(), serde_json::json!({}));
     }
 }

--- a/src/route/costing/mod.rs
+++ b/src/route/costing/mod.rs
@@ -93,6 +93,9 @@ mod test {
     use super::*;
     #[test]
     fn serialisation() {
-        assert_eq!(serde_json::to_value(Costing::default()).unwrap(), serde_json::json!({"costing": "auto", "costing_options": {}}));
+        assert_eq!(
+            serde_json::to_value(Costing::default()).unwrap(),
+            serde_json::json!({"costing": "auto", "costing_options": {}})
+        );
     }
 }

--- a/src/route/costing/mod.rs
+++ b/src/route/costing/mod.rs
@@ -93,11 +93,6 @@ mod test {
     use super::*;
     #[test]
     fn serialisation() {
-        insta::assert_json_snapshot!(Costing::Auto(Default::default()),@r#"
-        {
-          "costing": "auto",
-          "costing_options": {}
-        }
-        "#)
+        assert_eq!(serde_json::to_value(Costing::default()).unwrap(), serde_json::json!({"costing": "auto", "costing_options": {}}));
     }
 }

--- a/src/route/costing/mod.rs
+++ b/src/route/costing/mod.rs
@@ -89,10 +89,10 @@ impl Default for Costing {
 }
 
 #[cfg(test)]
-mod test{
+mod test {
     use super::*;
     #[test]
-    fn serialisation(){
+    fn serialisation() {
         insta::assert_json_snapshot!(Costing::Auto(Default::default()),@r#"
         {
           "costing": "auto",

--- a/src/route/costing/mod.rs
+++ b/src/route/costing/mod.rs
@@ -87,3 +87,17 @@ impl Default for Costing {
         Self::Auto(Default::default())
     }
 }
+
+#[cfg(test)]
+mod test{
+    use super::*;
+    #[test]
+    fn serialisation(){
+        insta::assert_json_snapshot!(Costing::Auto(Default::default()),@r#"
+        {
+          "costing": "auto",
+          "costing_options": {}
+        }
+        "#)
+    }
+}

--- a/src/route/costing/motor_scooter.rs
+++ b/src/route/costing/motor_scooter.rs
@@ -8,45 +8,83 @@ use serde::{Deserialize, Serialize};
 /// Factors unique to travel by motor_scooter influence the resulting route.
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct MotorScooterCostingOptions {
+    #[serde(skip_serializing_if = "Option::is_none")]
     maneuver_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     gate_cost: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     gate_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     private_access_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     destination_only_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     toll_booth_cost: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     toll_booth_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     ferry_cost: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     use_ferry: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     use_highways: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     use_tolls: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     use_living_streets: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     use_tracks: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     service_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     service_factor: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     country_crossing_cost: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     country_crossing_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     shortest: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     use_distance: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     disable_hierarchy_pruning: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     top_speed: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     fixed_speed: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     closure_factor: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     ignore_closures: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     ignore_restrictions: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     ignore_oneways: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     ignore_non_vehicular_restrictions: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     ignore_access: Option<bool>,
     // -- ↓ auto/motor_scooter only ↓ --
+    #[serde(skip_serializing_if = "Option::is_none")]
     speed_types: Option<UsedSpeedSources>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     height: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     width: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     exclude_unpaved: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     exclude_cash_only_tolls: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     include_hov2: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     include_hov3: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     include_hot: Option<bool>,
     // -- ↓ motor_scooter only ↓ --
+    #[serde(skip_serializing_if = "Option::is_none")]
     use_primary: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     use_hills: Option<f32>,
 }
 
@@ -476,4 +514,12 @@ pub enum UsedSpeedSources {
     Predicted,
     #[serde(rename = "current")]
     Current,
+}
+#[cfg(test)]
+mod test{
+    use super::*;
+    #[test]
+    fn serialisation(){
+        insta::assert_json_snapshot!(MotorScooterCostingOptions::default(),@"{}")
+    }
 }

--- a/src/route/costing/motor_scooter.rs
+++ b/src/route/costing/motor_scooter.rs
@@ -483,6 +483,6 @@ mod test {
     use super::*;
     #[test]
     fn serialisation() {
-        insta::assert_json_snapshot!(MotorScooterCostingOptions::default(),@"{}")
+        assert_eq!(serde_json::to_value(MotorScooterCostingOptions::default()).unwrap(), serde_json::json!({}));
     }
 }

--- a/src/route/costing/motor_scooter.rs
+++ b/src/route/costing/motor_scooter.rs
@@ -6,85 +6,48 @@ use serde::{Deserialize, Serialize};
 /// offers options for tuning motor_scooter routes.
 ///
 /// Factors unique to travel by motor_scooter influence the resulting route.
+#[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct MotorScooterCostingOptions {
-    #[serde(skip_serializing_if = "Option::is_none")]
     maneuver_penalty: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     gate_cost: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     gate_penalty: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     private_access_penalty: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     destination_only_penalty: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     toll_booth_cost: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     toll_booth_penalty: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     ferry_cost: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     use_ferry: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     use_highways: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     use_tolls: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     use_living_streets: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     use_tracks: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     service_penalty: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     service_factor: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     country_crossing_cost: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     country_crossing_penalty: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     shortest: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     use_distance: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     disable_hierarchy_pruning: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     top_speed: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     fixed_speed: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     closure_factor: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     ignore_closures: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     ignore_restrictions: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     ignore_oneways: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     ignore_non_vehicular_restrictions: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     ignore_access: Option<bool>,
     // -- ↓ auto/motor_scooter only ↓ --
-    #[serde(skip_serializing_if = "Option::is_none")]
     speed_types: Option<UsedSpeedSources>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     height: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     width: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     exclude_unpaved: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     exclude_cash_only_tolls: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     include_hov2: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     include_hov3: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     include_hot: Option<bool>,
     // -- ↓ motor_scooter only ↓ --
-    #[serde(skip_serializing_if = "Option::is_none")]
     use_primary: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     use_hills: Option<f32>,
 }
 

--- a/src/route/costing/motor_scooter.rs
+++ b/src/route/costing/motor_scooter.rs
@@ -483,6 +483,9 @@ mod test {
     use super::*;
     #[test]
     fn serialisation() {
-        assert_eq!(serde_json::to_value(MotorScooterCostingOptions::default()).unwrap(), serde_json::json!({}));
+        assert_eq!(
+            serde_json::to_value(MotorScooterCostingOptions::default()).unwrap(),
+            serde_json::json!({})
+        );
     }
 }

--- a/src/route/costing/motor_scooter.rs
+++ b/src/route/costing/motor_scooter.rs
@@ -516,10 +516,10 @@ pub enum UsedSpeedSources {
     Current,
 }
 #[cfg(test)]
-mod test{
+mod test {
     use super::*;
     #[test]
-    fn serialisation(){
+    fn serialisation() {
         insta::assert_json_snapshot!(MotorScooterCostingOptions::default(),@"{}")
     }
 }

--- a/src/route/costing/motorcycle.rs
+++ b/src/route/costing/motorcycle.rs
@@ -458,6 +458,6 @@ mod test {
     use super::*;
     #[test]
     fn serialisation() {
-        insta::assert_json_snapshot!(MotorcycleCostingOptions::default(),@"{}")
+        assert_eq!(serde_json::to_value(MotorcycleCostingOptions::default()).unwrap(), serde_json::json!({}));
     }
 }

--- a/src/route/costing/motorcycle.rs
+++ b/src/route/costing/motorcycle.rs
@@ -3,83 +3,47 @@ use serde::{Deserialize, Serialize};
 /// By default, motorcycle costing will default to higher class roads.
 /// The costing model recognizes factors unique to motorcycle travel and offers options for tuning
 /// motorcycle routes.
+#[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct MotorcycleCostingOptions {
-    #[serde(skip_serializing_if = "Option::is_none")]
     maneuver_penalty: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     gate_cost: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     gate_penalty: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     private_access_penalty: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     destination_only_penalty: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     toll_booth_cost: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     toll_booth_penalty: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     ferry_cost: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     use_ferry: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     use_highways: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     use_tolls: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     use_living_streets: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     use_tracks: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     service_penalty: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     service_factor: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     country_crossing_cost: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     country_crossing_penalty: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     shortest: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     use_distance: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     disable_hierarchy_pruning: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     top_speed: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     fixed_speed: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     closure_factor: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     ignore_closures: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     ignore_restrictions: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     ignore_oneways: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     ignore_non_vehicular_restrictions: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     ignore_access: Option<bool>,
     // -- ↓ auto / motorcycle only ↓ --
-    #[serde(skip_serializing_if = "Option::is_none")]
     speed_types: Option<UsedSpeedSources>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     height: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     width: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     exclude_unpaved: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     exclude_cash_only_tolls: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     include_hov2: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     include_hov3: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     include_hot: Option<bool>,
     // -- ↓ motorcycle only ↓ --
-    #[serde(skip_serializing_if = "Option::is_none")]
     use_trails: Option<f32>,
 }
 impl MotorcycleCostingOptions {

--- a/src/route/costing/motorcycle.rs
+++ b/src/route/costing/motorcycle.rs
@@ -458,6 +458,9 @@ mod test {
     use super::*;
     #[test]
     fn serialisation() {
-        assert_eq!(serde_json::to_value(MotorcycleCostingOptions::default()).unwrap(), serde_json::json!({}));
+        assert_eq!(
+            serde_json::to_value(MotorcycleCostingOptions::default()).unwrap(),
+            serde_json::json!({})
+        );
     }
 }

--- a/src/route/costing/motorcycle.rs
+++ b/src/route/costing/motorcycle.rs
@@ -5,44 +5,81 @@ use serde::{Deserialize, Serialize};
 /// motorcycle routes.
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct MotorcycleCostingOptions {
+    #[serde(skip_serializing_if = "Option::is_none")]
     maneuver_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     gate_cost: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     gate_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     private_access_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     destination_only_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     toll_booth_cost: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     toll_booth_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     ferry_cost: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     use_ferry: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     use_highways: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     use_tolls: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     use_living_streets: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     use_tracks: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     service_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     service_factor: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     country_crossing_cost: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     country_crossing_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     shortest: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     use_distance: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     disable_hierarchy_pruning: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     top_speed: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     fixed_speed: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     closure_factor: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     ignore_closures: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     ignore_restrictions: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     ignore_oneways: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     ignore_non_vehicular_restrictions: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     ignore_access: Option<bool>,
     // -- ↓ auto / motorcycle only ↓ --
+    #[serde(skip_serializing_if = "Option::is_none")]
     speed_types: Option<UsedSpeedSources>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     height: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     width: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     exclude_unpaved: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     exclude_cash_only_tolls: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     include_hov2: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     include_hov3: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     include_hot: Option<bool>,
     // -- ↓ motorcycle only ↓ --
+    #[serde(skip_serializing_if = "Option::is_none")]
     use_trails: Option<f32>,
 }
 impl MotorcycleCostingOptions {
@@ -450,4 +487,13 @@ pub enum UsedSpeedSources {
     Predicted,
     #[serde(rename = "current")]
     Current,
+}
+
+#[cfg(test)]
+mod test{
+    use super::*;
+    #[test]
+    fn serialisation(){
+        insta::assert_json_snapshot!(MotorcycleCostingOptions::default(),@"{}")
+    }
 }

--- a/src/route/costing/motorcycle.rs
+++ b/src/route/costing/motorcycle.rs
@@ -490,10 +490,10 @@ pub enum UsedSpeedSources {
 }
 
 #[cfg(test)]
-mod test{
+mod test {
     use super::*;
     #[test]
-    fn serialisation(){
+    fn serialisation() {
         insta::assert_json_snapshot!(MotorcycleCostingOptions::default(),@"{}")
     }
 }

--- a/src/route/costing/multimodal.rs
+++ b/src/route/costing/multimodal.rs
@@ -31,6 +31,9 @@ mod test {
     use super::*;
     #[test]
     fn serialisation() {
-        assert_eq!(serde_json::to_value(MultimodalCostingOptions::default()).unwrap(), serde_json::json!({}))
+        assert_eq!(
+            serde_json::to_value(MultimodalCostingOptions::default()).unwrap(),
+            serde_json::json!({})
+        )
     }
 }

--- a/src/route/costing/multimodal.rs
+++ b/src/route/costing/multimodal.rs
@@ -1,10 +1,9 @@
 use serde::{Deserialize, Serialize};
 
+#[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct MultimodalCostingOptions {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pedestrian: Option<super::pedestrian::PedestrianCostingOptions>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     transit: Option<super::transit::TransitCostingOptions>,
 }
 impl MultimodalCostingOptions {

--- a/src/route/costing/multimodal.rs
+++ b/src/route/costing/multimodal.rs
@@ -31,6 +31,6 @@ mod test {
     use super::*;
     #[test]
     fn serialisation() {
-        insta::assert_json_snapshot!(MultimodalCostingOptions::default(),@"{}")
+        assert_eq!(serde_json::to_value(MultimodalCostingOptions::default()).unwrap(), serde_json::json!({}))
     }
 }

--- a/src/route/costing/multimodal.rs
+++ b/src/route/costing/multimodal.rs
@@ -28,10 +28,10 @@ impl MultimodalCostingOptions {
 }
 
 #[cfg(test)]
-mod test{
+mod test {
     use super::*;
     #[test]
-    fn serialisation(){
+    fn serialisation() {
         insta::assert_json_snapshot!(MultimodalCostingOptions::default(),@"{}")
     }
 }

--- a/src/route/costing/multimodal.rs
+++ b/src/route/costing/multimodal.rs
@@ -2,7 +2,9 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct MultimodalCostingOptions {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pedestrian: Option<super::pedestrian::PedestrianCostingOptions>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     transit: Option<super::transit::TransitCostingOptions>,
 }
 impl MultimodalCostingOptions {
@@ -22,5 +24,14 @@ impl MultimodalCostingOptions {
     pub fn pedestrian(mut self, pedestrian: super::pedestrian::PedestrianCostingOptions) -> Self {
         self.pedestrian = Some(pedestrian);
         self
+    }
+}
+
+#[cfg(test)]
+mod test{
+    use super::*;
+    #[test]
+    fn serialisation(){
+        insta::assert_json_snapshot!(MultimodalCostingOptions::default(),@"{}")
     }
 }

--- a/src/route/costing/pedestrian.rs
+++ b/src/route/costing/pedestrian.rs
@@ -1,52 +1,30 @@
 use serde::{Deserialize, Serialize};
 
+#[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct PedestrianCostingOptions {
-    #[serde(skip_serializing_if = "Option::is_none")]
     walking_speed: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     walkway_factor: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     sidewalk_factor: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     alley_factor: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     driveway_factor: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     step_penalty: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     use_ferry: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     use_living_streets: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     use_tracks: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     use_hills: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     use_lit: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     service_penalty: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     service_factor: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     destination_only_penalty: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     max_hiking_difficulty: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     bss_rent_cost: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     bss_rent_penalty: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     shortest: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     max_distance: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     transit_start_end_max_distance: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     transit_transfer_max_distance: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     r#type: Option<PedestrianType>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     mode_factor: Option<f32>,
 }
 impl PedestrianCostingOptions {

--- a/src/route/costing/pedestrian.rs
+++ b/src/route/costing/pedestrian.rs
@@ -316,12 +316,11 @@ pub enum PedestrianType {
     Blind,
 }
 
-
 #[cfg(test)]
-mod test{
+mod test {
     use super::*;
     #[test]
-    fn serialisation(){
+    fn serialisation() {
         insta::assert_json_snapshot!(PedestrianCostingOptions::default(),@"{}")
     }
 }

--- a/src/route/costing/pedestrian.rs
+++ b/src/route/costing/pedestrian.rs
@@ -2,28 +2,51 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct PedestrianCostingOptions {
+    #[serde(skip_serializing_if = "Option::is_none")]
     walking_speed: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     walkway_factor: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     sidewalk_factor: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     alley_factor: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     driveway_factor: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     step_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     use_ferry: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     use_living_streets: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     use_tracks: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     use_hills: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     use_lit: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     service_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     service_factor: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     destination_only_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     max_hiking_difficulty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     bss_rent_cost: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     bss_rent_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     shortest: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     max_distance: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     transit_start_end_max_distance: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     transit_transfer_max_distance: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     r#type: Option<PedestrianType>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     mode_factor: Option<f32>,
 }
 impl PedestrianCostingOptions {
@@ -291,4 +314,14 @@ pub enum PedestrianType {
     Foot,
     #[serde(rename = "blind")]
     Blind,
+}
+
+
+#[cfg(test)]
+mod test{
+    use super::*;
+    #[test]
+    fn serialisation(){
+        insta::assert_json_snapshot!(PedestrianCostingOptions::default(),@"{}")
+    }
 }

--- a/src/route/costing/pedestrian.rs
+++ b/src/route/costing/pedestrian.rs
@@ -299,6 +299,9 @@ mod test {
     use super::*;
     #[test]
     fn serialisation() {
-        assert_eq!(serde_json::to_value(PedestrianCostingOptions::default()).unwrap(), serde_json::json!({}));
+        assert_eq!(
+            serde_json::to_value(PedestrianCostingOptions::default()).unwrap(),
+            serde_json::json!({})
+        );
     }
 }

--- a/src/route/costing/pedestrian.rs
+++ b/src/route/costing/pedestrian.rs
@@ -299,6 +299,6 @@ mod test {
     use super::*;
     #[test]
     fn serialisation() {
-        insta::assert_json_snapshot!(PedestrianCostingOptions::default(),@"{}")
+        assert_eq!(serde_json::to_value(PedestrianCostingOptions::default()).unwrap(), serde_json::json!({}));
     }
 }

--- a/src/route/costing/transit.rs
+++ b/src/route/costing/transit.rs
@@ -160,6 +160,6 @@ mod test {
     use super::*;
     #[test]
     fn serialisation() {
-        insta::assert_json_snapshot!(TransitCostingOptions::default(),@"{}")
+        assert_eq!(serde_json::to_value(TransitCostingOptions::default()).unwrap(), serde_json::json!({}));
     }
 }

--- a/src/route/costing/transit.rs
+++ b/src/route/costing/transit.rs
@@ -145,10 +145,10 @@ struct Filter {
 }
 
 #[cfg(test)]
-mod test{
+mod test {
     use super::*;
     #[test]
-    fn serialisation(){
+    fn serialisation() {
         insta::assert_json_snapshot!(TransitCostingOptions::default(),@"{}")
     }
 }

--- a/src/route/costing/transit.rs
+++ b/src/route/costing/transit.rs
@@ -88,7 +88,10 @@ impl TransitCostingOptions {
         ids: impl IntoIterator<Item = impl ToString>,
         action: Action,
     ) -> Self {
-        let new_filter = Filter { ids: ids.into_iter().map(|s| s.to_string()).collect(), action, };
+        let new_filter = Filter {
+            ids: ids.into_iter().map(|s| s.to_string()).collect(),
+            action,
+        };
         if let Some(ref mut filters) = self.filters {
             filters.routes = Some(new_filter);
         } else {
@@ -160,6 +163,9 @@ mod test {
     use super::*;
     #[test]
     fn serialisation() {
-        assert_eq!(serde_json::to_value(TransitCostingOptions::default()).unwrap(), serde_json::json!({}));
+        assert_eq!(
+            serde_json::to_value(TransitCostingOptions::default()).unwrap(),
+            serde_json::json!({})
+        );
     }
 }

--- a/src/route/costing/transit.rs
+++ b/src/route/costing/transit.rs
@@ -143,3 +143,12 @@ struct Filter {
     ids: Vec<String>,
     action: Action,
 }
+
+#[cfg(test)]
+mod test{
+    use super::*;
+    #[test]
+    fn serialisation(){
+        insta::assert_json_snapshot!(TransitCostingOptions::default(),@"{}")
+    }
+}

--- a/src/route/costing/transit.rs
+++ b/src/route/costing/transit.rs
@@ -1,15 +1,12 @@
 use serde::{Deserialize, Serialize};
 
+#[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct TransitCostingOptions {
-    #[serde(skip_serializing_if = "Option::is_none")]
     use_bus: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     use_rail: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     use_transfers: Option<f32>,
-    #[serde(skip_serializing_if = "Filters::is_empty")]
-    filters: Filters,
+    filters: Option<Filters>,
 }
 impl TransitCostingOptions {
     pub fn builder() -> Self {
@@ -60,10 +57,18 @@ impl TransitCostingOptions {
         ids: impl IntoIterator<Item = impl ToString>,
         action: Action,
     ) -> Self {
-        self.filters.stops = Some(Filter {
+        let new_filter = Filter {
             ids: ids.into_iter().map(|s| s.to_string()).collect(),
             action,
-        });
+        };
+        if let Some(ref mut filters) = self.filters {
+            filters.stops = Some(new_filter);
+        } else {
+            self.filters = Some(Filters {
+                stops: Some(new_filter),
+                ..Default::default()
+            });
+        }
         self
     }
     /// Sets a filter for one or more `routes`
@@ -83,10 +88,15 @@ impl TransitCostingOptions {
         ids: impl IntoIterator<Item = impl ToString>,
         action: Action,
     ) -> Self {
-        self.filters.routes = Some(Filter {
-            ids: ids.into_iter().map(|s| s.to_string()).collect(),
-            action,
-        });
+        let new_filter = Filter { ids: ids.into_iter().map(|s| s.to_string()).collect(), action, };
+        if let Some(ref mut filters) = self.filters {
+            filters.routes = Some(new_filter);
+        } else {
+            self.filters = Some(Filters {
+                routes: Some(new_filter),
+                ..Default::default()
+            });
+        }
         self
     }
     /// Sets a filter for one or more `operators`.
@@ -106,10 +116,18 @@ impl TransitCostingOptions {
         ids: impl IntoIterator<Item = impl ToString>,
         action: Action,
     ) -> Self {
-        self.filters.operators = Some(Filter {
+        let new_filter = Filter {
             ids: ids.into_iter().map(|s| s.to_string()).collect(),
             action,
-        });
+        };
+        if let Some(ref mut filters) = self.filters {
+            filters.operators = Some(new_filter);
+        } else {
+            self.filters = Some(Filters {
+                operators: Some(new_filter),
+                ..Default::default()
+            });
+        }
         self
     }
 }
@@ -123,19 +141,12 @@ pub enum Action {
     Exclude,
 }
 
+#[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 struct Filters {
-    #[serde(skip_serializing_if = "Option::is_none")]
     routes: Option<Filter>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     operators: Option<Filter>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     stops: Option<Filter>,
-}
-impl Filters {
-    fn is_empty(&self) -> bool {
-        self.routes.is_none() && self.operators.is_none() && self.stops.is_none()
-    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]

--- a/src/route/costing/truck.rs
+++ b/src/route/costing/truck.rs
@@ -1,79 +1,44 @@
 use serde::{Deserialize, Serialize};
 
+#[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct TruckCostingOptions {
-    #[serde(skip_serializing_if = "Option::is_none")]
     maneuver_penalty: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     gate_cost: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     gate_penalty: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     private_access_penalty: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     destination_only_penalty: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     toll_booth_cost: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     toll_booth_penalty: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     ferry_cost: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     use_ferry: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     use_highways: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     use_tolls: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     use_living_streets: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     use_tracks: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     service_penalty: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     service_factor: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     country_crossing_cost: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     country_crossing_penalty: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     shortest: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     use_distance: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     disable_hierarchy_pruning: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     top_speed: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     fixed_speed: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     closure_factor: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     ignore_closures: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     ignore_restrictions: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     ignore_oneways: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     ignore_non_vehicular_restrictions: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     ignore_access: Option<bool>,
     // -- ↓ truck only ↓ --
-    #[serde(skip_serializing_if = "Option::is_none")]
     length: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     weight: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     axle_load: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     axle_count: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     hazmat: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     hgv_no_access_penalty: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     low_class_penalty: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     use_truck_route: Option<f32>,
 }
 impl TruckCostingOptions {

--- a/src/route/costing/truck.rs
+++ b/src/route/costing/truck.rs
@@ -415,6 +415,6 @@ mod test {
     use super::*;
     #[test]
     fn serialisation() {
-        insta::assert_json_snapshot!(TruckCostingOptions::default(),@"{}")
+        assert_eq!(serde_json::to_value(TruckCostingOptions::default()).unwrap(), serde_json::json!({}))
     }
 }

--- a/src/route/costing/truck.rs
+++ b/src/route/costing/truck.rs
@@ -445,12 +445,11 @@ impl TruckCostingOptions {
     }
 }
 
-
 #[cfg(test)]
-mod test{
+mod test {
     use super::*;
     #[test]
-    fn serialisation(){
+    fn serialisation() {
         insta::assert_json_snapshot!(TruckCostingOptions::default(),@"{}")
     }
 }

--- a/src/route/costing/truck.rs
+++ b/src/route/costing/truck.rs
@@ -2,42 +2,78 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct TruckCostingOptions {
+    #[serde(skip_serializing_if = "Option::is_none")]
     maneuver_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     gate_cost: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     gate_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     private_access_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     destination_only_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     toll_booth_cost: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     toll_booth_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     ferry_cost: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     use_ferry: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     use_highways: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     use_tolls: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     use_living_streets: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     use_tracks: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     service_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     service_factor: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     country_crossing_cost: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     country_crossing_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     shortest: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     use_distance: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     disable_hierarchy_pruning: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     top_speed: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     fixed_speed: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     closure_factor: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     ignore_closures: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     ignore_restrictions: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     ignore_oneways: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     ignore_non_vehicular_restrictions: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     ignore_access: Option<bool>,
     // -- ↓ truck only ↓ --
+    #[serde(skip_serializing_if = "Option::is_none")]
     length: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     weight: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     axle_load: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     axle_count: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     hazmat: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     hgv_no_access_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     low_class_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     use_truck_route: Option<f32>,
 }
 impl TruckCostingOptions {
@@ -406,5 +442,15 @@ impl TruckCostingOptions {
     pub fn use_truck_route(mut self, use_truck_route: f32) -> Self {
         self.use_truck_route = Some(use_truck_route);
         self
+    }
+}
+
+
+#[cfg(test)]
+mod test{
+    use super::*;
+    #[test]
+    fn serialisation(){
+        insta::assert_json_snapshot!(TruckCostingOptions::default(),@"{}")
     }
 }

--- a/src/route/costing/truck.rs
+++ b/src/route/costing/truck.rs
@@ -415,6 +415,9 @@ mod test {
     use super::*;
     #[test]
     fn serialisation() {
-        assert_eq!(serde_json::to_value(TruckCostingOptions::default()).unwrap(), serde_json::json!({}))
+        assert_eq!(
+            serde_json::to_value(TruckCostingOptions::default()).unwrap(),
+            serde_json::json!({})
+        )
     }
 }

--- a/src/route/mod.rs
+++ b/src/route/mod.rs
@@ -911,10 +911,6 @@ mod test {
     use super::*;
     #[test]
     fn serialisation() {
-        insta::assert_json_snapshot!(Manifest::default(),@r#"
-        {
-          "locations": []
-        }
-        "#);
+        assert_eq!(serde_json::to_value(Manifest::default()).unwrap(), serde_json::json!({"locations": []}));
     }
 }

--- a/src/route/mod.rs
+++ b/src/route/mod.rs
@@ -911,6 +911,9 @@ mod test {
     use super::*;
     #[test]
     fn serialisation() {
-        assert_eq!(serde_json::to_value(Manifest::default()).unwrap(), serde_json::json!({"locations": []}));
+        assert_eq!(
+            serde_json::to_value(Manifest::default()).unwrap(),
+            serde_json::json!({"locations": []})
+        );
     }
 }

--- a/src/route/mod.rs
+++ b/src/route/mod.rs
@@ -379,17 +379,28 @@ pub enum Units {
 #[derive(Serialize, Default, Debug)]
 pub struct Manifest {
     #[serde(flatten)]
-    costing: costing::Costing,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    costing: Option<costing::Costing>,
     locations: Vec<Location>,
-    units: Units,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    units: Option<Units>,
+    #[serde(skip_serializing_if = "String::is_empty")]
     id: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
     language: String,
-    directions_type: DirectionsType,
-    alternates: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    directions_type: Option<DirectionsType>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    alternates: Option<i32>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     exclude_locations: Vec<Location>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     exclude_polygons: Vec<Vec<Coordinate>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     linear_references: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     prioritize_bidirectional: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     roundabout_exits: Option<bool>,
 }
 
@@ -404,7 +415,7 @@ impl Manifest {
     ///
     /// Default: [`costing::Costing::Auto`]
     pub fn costing(mut self, costing: costing::Costing) -> Self {
-        self.costing = costing;
+        self.costing = Some(costing);
         self
     }
 
@@ -434,7 +445,7 @@ impl Manifest {
     ///
     /// Default: [`Units::Metric`]
     pub fn units(mut self, units: Units) -> Self {
-        self.units = units;
+        self.units = Some(units);
         self
     }
 
@@ -467,7 +478,7 @@ impl Manifest {
     ///
     /// Default: [`DirectionsType::Instructions`]
     pub fn directions_type(mut self, directions_type: DirectionsType) -> Self {
-        self.directions_type = directions_type;
+        self.directions_type = Some(directions_type);
         self
     }
 
@@ -479,7 +490,7 @@ impl Manifest {
     /// - multipoint routes (i.e. routes with more than 2 locations) and
     /// - time dependent routes
     pub fn alternates(mut self, alternates: i32) -> Self {
-        self.alternates = alternates;
+        self.alternates = Some(alternates);
         self
     }
 
@@ -904,62 +915,11 @@ pub struct Location {
 mod test {
     use super::*;
     #[test]
-    fn serialisation_snapshots() {
-        let manifest = Manifest::default();
-        assert_eq!(
-            serde_json::to_value(manifest).unwrap(),
-            serde_json::json!({
-                  "costing": "auto",
-                  "costing_options": {
-                      "maneuver_penalty": null,
-                      "gate_cost": null,
-                      "gate_penalty": null,
-                      "private_access_penalty": null,
-                      "destination_only_penalty": null,
-                      "toll_booth_cost": null,
-                      "toll_booth_penalty": null,
-                      "ferry_cost": null,
-                      "use_ferry": null,
-                      "use_highways": null,
-                      "use_tolls": null,
-                      "use_living_streets": null,
-                      "use_tracks": null,
-                      "service_penalty": null,
-                      "service_factor": null,
-                      "country_crossing_cost": null,
-                      "country_crossing_penalty": null,
-                      "shortest": null,
-                      "use_distance": null,
-                      "disable_hierarchy_pruning": null,
-                      "top_speed": null,
-                      "fixed_speed": null,
-                      "closure_factor": null,
-                      "ignore_closures": null,
-                      "ignore_restrictions": null,
-                      "ignore_oneways": null,
-                      "ignore_non_vehicular_restrictions": null,
-                      "ignore_access": null,
-                      "speed_types": null,
-                      "height": null,
-                      "width": null,
-                      "exclude_unpaved": null,
-                      "exclude_cash_only_tolls": null,
-                      "include_hov2": null,
-                      "include_hov3": null,
-                      "include_hot": null
-                    },
-               "locations": [],
-               "units": "kilometers",
-               "id": "",
-               "language": "",
-               "directions_type": "instructions",
-               "alternates": 0,
-               "exclude_locations": [],
-               "exclude_polygons": [],
-               "linear_references": null,
-               "prioritize_bidirectional": null,
-               "roundabout_exits": null
-            })
-        )
+    fn serialisation() {
+        insta::assert_json_snapshot!(Manifest::default(),@r#"
+        {
+          "locations": []
+        }
+        "#);
     }
 }


### PR DESCRIPTION
made sure that only the options which are being set are send over the wire

The main reason is that debugging is much simpler if `none` is not also send.
`insta` is added to make snapshot tests not such a pain.