### PR TITLE
chore!: audit pedantic cippy lints

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,10 +25,10 @@ pub enum Error {
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            Error::Reqwest(e) => write!(f, "reqwest error: {}", e),
-            Error::Url(e) => write!(f, "url error: {}", e),
-            Error::Serde(e) => write!(f, "serde error: {}", e),
-            Error::RemoteError(e) => write!(f, "remote error: {:?}", e),
+            Self::Reqwest(e) => write!(f, "reqwest error: {e}"),
+            Self::Url(e) => write!(f, "url error: {e}"),
+            Self::Serde(e) => write!(f, "serde error: {e}"),
+            Self::RemoteError(e) => write!(f, "remote error: {e:?}"),
         }
     }
 }

--- a/src/route/costing/auto.rs
+++ b/src/route/costing/auto.rs
@@ -42,8 +42,9 @@ pub struct AutoCostingOptions {
     include_hot: Option<bool>,
 }
 impl AutoCostingOptions {
+    #[must_use]
     pub fn builder() -> Self {
-        Default::default()
+        Self::default()
     }
 
     /// A cost applied when a [gate](http://wiki.openstreetmap.org/wiki/Tag:barrier%3Dgate) with

--- a/src/route/costing/bicycle.rs
+++ b/src/route/costing/bicycle.rs
@@ -46,8 +46,9 @@ pub struct BicycleCostingOptions {
     service_penalty: Option<f32>,
 }
 impl BicycleCostingOptions {
+    #[must_use]
     pub fn builder() -> Self {
-        Default::default()
+        Self::default()
     }
 
     /// Specifies the [`BicycleType`].

--- a/src/route/costing/motor_scooter.rs
+++ b/src/route/costing/motor_scooter.rs
@@ -52,8 +52,9 @@ pub struct MotorScooterCostingOptions {
 }
 
 impl MotorScooterCostingOptions {
+    #[must_use]
     pub fn builder() -> Self {
-        Default::default()
+        Self::default()
     }
 
     /// A cost applied when a [gate](http://wiki.openstreetmap.org/wiki/Tag:barrier%3Dgate) with

--- a/src/route/costing/motorcycle.rs
+++ b/src/route/costing/motorcycle.rs
@@ -47,8 +47,9 @@ pub struct MotorcycleCostingOptions {
     use_trails: Option<f32>,
 }
 impl MotorcycleCostingOptions {
+    #[must_use]
     pub fn builder() -> Self {
-        Default::default()
+        Self::default()
     }
 
     /// A cost applied when a [gate](http://wiki.openstreetmap.org/wiki/Tag:barrier%3Dgate) with

--- a/src/route/costing/multimodal.rs
+++ b/src/route/costing/multimodal.rs
@@ -7,8 +7,9 @@ pub struct MultimodalCostingOptions {
     transit: Option<super::transit::TransitCostingOptions>,
 }
 impl MultimodalCostingOptions {
+    #[must_use]
     pub fn builder() -> Self {
-        Default::default()
+        Self::default()
     }
     /// Allows configuration of the transit Costing options
     ///

--- a/src/route/costing/pedestrian.rs
+++ b/src/route/costing/pedestrian.rs
@@ -28,8 +28,9 @@ pub struct PedestrianCostingOptions {
     mode_factor: Option<f32>,
 }
 impl PedestrianCostingOptions {
+    #[must_use]
     pub fn builder() -> Self {
-        Default::default()
+        Self::default()
     }
 
     /// Walking speed in kilometers per hour.

--- a/src/route/costing/transit.rs
+++ b/src/route/costing/transit.rs
@@ -9,8 +9,9 @@ pub struct TransitCostingOptions {
     filters: Option<Filters>,
 }
 impl TransitCostingOptions {
+    #[must_use]
     pub fn builder() -> Self {
-        Default::default()
+        Self::default()
     }
     /// User's desire to use buses.
     ///
@@ -83,7 +84,7 @@ impl TransitCostingOptions {
     /// the OneStop ID `NYC_AUR`, similar with operators/agencies
     ///
     /// **Tip**: Can be combined with [`Self::filter_stops`] and/or [`Self::filter_operators`]
-    pub fn filter_routes<S>(
+    pub fn filter_routes(
         mut self,
         ids: impl IntoIterator<Item = impl ToString>,
         action: Action,

--- a/src/route/costing/truck.rs
+++ b/src/route/costing/truck.rs
@@ -42,8 +42,9 @@ pub struct TruckCostingOptions {
     use_truck_route: Option<f32>,
 }
 impl TruckCostingOptions {
+    #[must_use]
     pub fn builder() -> Self {
-        Default::default()
+        Self::default()
     }
 
     /// A cost applied when a [gate](http://wiki.openstreetmap.org/wiki/Tag:barrier%3Dgate) with

--- a/src/route/mod.rs
+++ b/src/route/mod.rs
@@ -20,7 +20,7 @@ pub struct Trip {
 #[cfg(feature = "gpx")]
 impl From<Trip> for gpx::Gpx {
     fn from(trip: Trip) -> Self {
-        let mut gpx = gpx::Gpx {
+        let mut gpx = Self {
             version: gpx::GpxVersion::Gpx11,
             creator: Some("valhalla".to_string()),
             ..Default::default()
@@ -138,7 +138,7 @@ pub struct Leg {
 #[cfg(feature = "gpx")]
 impl From<&Leg> for gpx::TrackSegment {
     fn from(leg: &Leg) -> Self {
-        gpx::TrackSegment {
+        Self {
             points: leg.shape[leg.maneuvers[0].begin_shape_index
                 ..leg.maneuvers[leg.maneuvers.len() - 1].end_shape_index]
                 .iter()
@@ -643,8 +643,9 @@ pub enum Side {
 #[cfg(feature = "gpx")]
 impl From<&Location> for gpx::Waypoint {
     fn from(location: &Location) -> Self {
-        let point = geo_types::Point::new(location.longitude as f64, location.latitude as f64);
-        let mut p = gpx::Waypoint::new(point);
+        let point =
+            geo_types::Point::new(f64::from(location.longitude), f64::from(location.latitude));
+        let mut p = Self::new(point);
         p.name.clone_from(&location.name);
         p
     }

--- a/src/shapes.rs
+++ b/src/shapes.rs
@@ -8,7 +8,7 @@ pub struct ShapePoint {
 
 impl From<&ShapePoint> for geo_types::Point {
     fn from(p: &ShapePoint) -> Self {
-        geo_types::Point::new(p.lon, p.lat)
+        Self::new(p.lon, p.lat)
     }
 }
 
@@ -26,7 +26,7 @@ fn decode_shape(encoded: &str) -> Vec<ShapePoint> {
             let mut byte = 0x20;
 
             while byte >= 0x20 {
-                byte = encoded.as_bytes()[i] as i32 - 63;
+                byte = i32::from(encoded.as_bytes()[i]) - 63;
                 i += 1;
                 ll[j] |= (byte & 0x1f) << shift;
                 shift += 5;
@@ -37,8 +37,8 @@ fn decode_shape(encoded: &str) -> Vec<ShapePoint> {
         }
 
         decoded.push(ShapePoint {
-            lon: -1.0 * ll[1] as f64 * inv,
-            lat: -1.0 * ll[0] as f64 * inv,
+            lon: -1.0 * f64::from(ll[1]) * inv,
+            lat: -1.0 * f64::from(ll[0]) * inv,
         });
     }
 


### PR DESCRIPTION
I went over the pedantic/nursery cippy lints to see if there is something that we might have overlooked.

Luckyly that has not revealed anything major.
Here are the changes:
- builders should be `#[must_use]`
- `Self` usage might be more idiomatic in some cases
- using `f64::from` instead of `.. as f64` where this is lossless