### PR TITLE
feat: add an async api alternative

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,7 +260,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -268,12 +267,6 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
-
-[[package]]
-name = "futures-io"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-sink"
@@ -294,13 +287,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
- "futures-io",
- "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
- "slab",
 ]
 
 [[package]]
@@ -866,9 +855,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
 name = "pin-utils"
@@ -915,7 +904,6 @@ dependencies = [
  "base64",
  "bytes",
  "encoding_rs",
- "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
@@ -1487,6 +1475,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "serde_with",
+ "tokio",
  "url",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,6 +260,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -267,6 +268,12 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-sink"
@@ -287,9 +294,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
+ "futures-io",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -904,6 +915,7 @@ dependencies = [
  "base64",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
@@ -1463,7 +1475,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "valhalla-client"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "geo-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "valhalla-client"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 description = "API client for the Valhalla routing engine"
 authors = ["Jelmer Vernooĳ <jelmer@jelmer.uk>", "Frank Elsinga <frank.elsinga@tum.de>"]
@@ -19,7 +19,9 @@ serde_json = "1.0.138"
 serde_repr = "0.1.19"
 serde_with = "3.12.0"
 url = "2.5.4"
+tokio = { version = "1", default-features = false, optional = true }
 
 [features]
-default = ["gpx"]
+default = ["gpx", "blocking"]
 gpx = ["dep:gpx"]
+blocking = ["dep:tokio"]

--- a/README.md
+++ b/README.md
@@ -13,10 +13,22 @@ These APIs are implemented:
 - [ ] [Expansion](https://valhalla.github.io/valhalla/api/expansion/api-reference/)
 - [x] [Status](https://valhalla.github.io/valhalla/api/status/api-reference/)
 
-## Examples
+## Features and usage
+
+We provide two clients:
+- async: [`valhalla_client::Valhalla`](https://docs.rs/valhalla-client/latest/valhalla_client/struct.Valhalla.html) and
+- sync: [`valhalla_client::blocking::Valhalla`](https://docs.rs/valhalla-client/latest/valhalla_client/blocking/struct.Valhalla.html) using the [tokyo runtime](https://tokio.rs/) internally to call the async version
+
+The second one is behind the (default-enabled) `blocking` feature, so if you don't need it, you can disable it via `default-features = false`.
+
+We also offer the (default-enabled) `gpx` feature.
+This enables [reading and writing GPX (GPS Exchange Format) files](https://docs.rs/gpx/latest/gpx/) for APIs where we have the needed context.
+
+## Example
 
 ```rust
-use valhalla_client::Valhalla;
+// an async version is available at valhalla_client::Valhalla
+use valhalla_client::blocking::Valhalla;
 use valhalla_client::route::{Location, Manifest};
 use valhalla_client::costing::{Costing};
 
@@ -35,3 +47,8 @@ println!("{:#?}", response);
 // If the gpx feature is enabled, you can convert the response to a gpx::Gpx object
 // let gpx = response.trip.into();
 ```
+
+For further examples, please see the different clients:
+- async: [`valhalla_client::Valhalla`](https://docs.rs/valhalla-client/latest/valhalla_client/struct.Valhalla.html) and
+- sync: [`valhalla_client::blocking::Valhalla`](https://docs.rs/valhalla-client/latest/valhalla_client/blocking/struct.Valhalla.html)
+

--- a/src/route.rs
+++ b/src/route.rs
@@ -611,7 +611,7 @@ impl Manifest {
     ///
     /// # Example:
     /// ```rust,no_run
-    /// use valhalla_client::Valhalla;
+    /// use valhalla_client::blocking::Valhalla;
     /// use valhalla_client::route::{Location, Manifest};
     /// use valhalla_client::costing::{Costing};
     ///
@@ -652,7 +652,7 @@ impl Manifest {
     ///
     /// # Example:
     /// ```rust,no_run
-    /// use valhalla_client::Valhalla;
+    /// use valhalla_client::blocking::Valhalla;
     /// use valhalla_client::route::{Location, Manifest};
     /// use valhalla_client::costing::{Costing};
     ///

--- a/src/status.rs
+++ b/src/status.rs
@@ -70,10 +70,10 @@ pub struct VerboseStatus {
     pub warnings: Vec<Value>,
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "blocking"))]
 mod tests {
     use super::*;
-    use crate::Valhalla;
+    use crate::blocking::Valhalla;
     #[test]
     fn test_status_verbose() {
         let request = Manifest::builder().verbose_output(true);


### PR DESCRIPTION
During implementing this API in my app I noticed that we currently don't have an async API interface.

This is somewhat inconvenient for async users => this PR adds an async interface.

The best way that I can come up with is sadly again pretty breaking.. What do you think?