### PR TITLE
use more idiomatic rust:

### DIFF
--- a/src/costing/transit.rs
+++ b/src/costing/transit.rs
@@ -61,13 +61,12 @@ impl TransitCostingOptions {
     ///
     /// **Tip**: Can be combined with [`Self::filter_routes`] and/or [`Self::filter_operators`]
     #[doc(hidden)] // TODO: enable once this works in valhalla
-    pub fn filter_stops(
-        mut self,
-        ids: impl IntoIterator<Item = impl ToString>,
-        action: Action,
-    ) -> Self {
+    pub fn filter_stops<S>(mut self, ids: impl IntoIterator<Item = S>, action: Action) -> Self
+    where
+        S: Into<String>,
+    {
         let new_filter = Filter {
-            ids: ids.into_iter().map(|s| s.to_string()).collect(),
+            ids: ids.into_iter().map(Into::into).collect(),
             action,
         };
         if let Some(ref mut filters) = self.transit.filters {
@@ -92,13 +91,12 @@ impl TransitCostingOptions {
     /// the OneStop ID `NYC_AUR`, similar with operators/agencies
     ///
     /// **Tip**: Can be combined with [`Self::filter_stops`] and/or [`Self::filter_operators`]
-    pub fn filter_routes(
-        mut self,
-        ids: impl IntoIterator<Item = impl ToString>,
-        action: Action,
-    ) -> Self {
+    pub fn filter_routes<S>(mut self, ids: impl IntoIterator<Item = S>, action: Action) -> Self
+    where
+        S: Into<String>,
+    {
         let new_filter = Filter {
-            ids: ids.into_iter().map(|s| s.to_string()).collect(),
+            ids: ids.into_iter().map(Into::into).collect(),
             action,
         };
         if let Some(ref mut filters) = self.transit.filters {
@@ -123,13 +121,12 @@ impl TransitCostingOptions {
     /// the OneStop ID `NYC_AUR`, similar with operators/agencies
     ///
     /// **Tip**: Can be combined with [`Self::filter_stops`] and/or [`Self::filter_routes`]
-    pub fn filter_operators(
-        mut self,
-        ids: impl IntoIterator<Item = impl ToString>,
-        action: Action,
-    ) -> Self {
+    pub fn filter_operators<S>(mut self, ids: impl IntoIterator<Item = S>, action: Action) -> Self
+    where
+        S: Into<String>,
+    {
         let new_filter = Filter {
-            ids: ids.into_iter().map(|s| s.to_string()).collect(),
+            ids: ids.into_iter().map(Into::into).collect(),
             action,
         };
         if let Some(ref mut filters) = self.transit.filters {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -500,7 +500,7 @@ impl Valhalla {
         name: &'static str,
     ) -> Result<Resp, Error> {
         if log::log_enabled!(log::Level::Trace) {
-            let request = serde_json::to_string(&manifest).unwrap();
+            let request = serde_json::to_string(&manifest).map_err(Error::Serde)?;
             trace!("Sending {name} request: {request}");
         }
         let mut url = self.base_url.clone();

--- a/src/shapes.rs
+++ b/src/shapes.rs
@@ -54,7 +54,9 @@ fn decode_shape_polyline6(encoded: &str) -> Vec<ShapePoint> {
     debug_assert!(!encoded.is_empty());
     // six degrees of precision in valhalla
     let inv = 1.0 / 1e6;
-    let mut decoded = Vec::new();
+    // Estimate capacity: polyline6 typically needs 5-10 bytes per coordinate pair
+    let estimated_points = encoded.len() / 8;
+    let mut decoded = Vec::with_capacity(estimated_points);
     let mut previous = [0, 0];
     let mut i = 0;
 
@@ -95,7 +97,7 @@ where
     D: serde::Deserializer<'de>,
 {
     let s = String::deserialize(deserializer)?;
-    Ok(decode_shape_polyline6(s.as_str()))
+    Ok(decode_shape_polyline6(&s))
 }
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
- Replace .unwrap() with proper error propagation in trace logging
- Optimize string conversions in transit filter methods using Into<String>
- Pre-allocate vector capacity in polyline6 decoding for better performance

(we probably need to bump semver, since these are changes to the public API I think?)